### PR TITLE
Depend on ansible-core instead of ansible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     py_modules=py_files,
     packages=files,
     install_requires=[
-        'ansible>=5.0.0',
+        'ansible-core>=2.12.0',
         'hvac>=1.2.1',
         'requests',
     ],


### PR DESCRIPTION
This is a tentative fix for #455, just seeing if the CI is happy with it.